### PR TITLE
Use "latest version" Zenodo DOI

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 This repository contains exports the signature and prevalence files exported in
 [TypicalMicrobiomeSignatures](https://github.com/waldronlab/TypicalMicrobiomeSignatures).
 The latest release versions are also available on Zenodo at
-[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.7622129.svg)](https://doi.org/10.5281/zenodo.7622129).
+[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.7544549.svg)](https://doi.org/10.5281/zenodo.7544549).
 Older versions are available at
 [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.6656514.svg)](https://doi.org/10.5281/zenodo.6656514).
 
@@ -11,3 +11,4 @@ The files are available under [Creative Commons Attribution 4.0
 International](https://creativecommons.org/licenses/by/4.0/legalcode).
 
 Each file contains a matrix of the prevalence of each signature at gut, skin, anterior nasal, oral cavity, and vagina. Each row is one signature.
+


### PR DESCRIPTION
There's a small section that says:
> Cite all versions? You can cite all versions by using the DOI 10.5281/zenodo.7544549. This DOI represents all versions, and will always resolve to the latest one.